### PR TITLE
Update jest to avoid warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "^25.1.0",
-    "jest": "^24.9.0",
+    "jest": "^25.3.0",
     "prettier": "^2.0.0",
     "ts-jest": "^25.1.0",
     "tslint": "^5.20.1",


### PR DESCRIPTION
I've getted the next warning testing this library:
```
ts-jest[versions] (WARN) Version 24.9.0 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=25.0.0 <26.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
```

So I've updated jest to the most recent version. All tests remain green. 