### PR TITLE
Remove request as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "Tools for Arabic language word games",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "dependencies": {
-    "request": "^2.88.0"
-  },
   "devDependencies": {
     "@types/jest": "^25.1.0",
     "jest": "^24.9.0",


### PR DESCRIPTION
Request is defined as a dependency but it's not used in the library. I think that it's a mistake installing libraries, so I've removed to avoid this warning installing packages that depends of `alif-toolkit`:

```
alif-toolkit > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
```